### PR TITLE
Allow access from other websites for the api

### DIFF
--- a/homometer/views.py
+++ b/homometer/views.py
@@ -21,7 +21,9 @@ def get_current_and_percent():
 
 def api(request):
     current, percent = get_current_and_percent()
-    return JsonResponse({"current": current, "percent": percent})
+    response = JsonResponse({"current": current, "percent": percent})
+    response["Access-Control-Allow-Origin"] = "*"
+    return response
 
 
 def index(request, minimal=False):


### PR DESCRIPTION
This PR allows to access the API from other websites, by allowing CORS.

--- 

Currently, it is not possible to access the API from other websites, as it is blocked through CORS.
With this PR, access from all origins is allowed, via `Access-Control-Allow-Origin: *` (https://developer.mozilla.org/de/docs/Web/HTTP/CORS#access-control-allow-origin)

While CORS should prevent security issues, I don't think this is a problem here, as we don't have any user data, or dynamic content.